### PR TITLE
画像クリックでコンテンツ切り替え機能を実装

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -16,8 +16,60 @@
 <script type="text/javascript">
 $(document).ready(function() {
   // usage.htmlとinstall.htmlの内容を変数として定義
-  var usageContent = "usage";
-  var installContent = "install";
+  var usageContent = `<h1><img alt="つかいかた" width="650" height="72" src="./images/images-subpage/h1_howtouse.png" /></h1>
+
+<p>Libron は Amazon のページから最寄りの図書館の蔵書を検索できる便利なツールです。<br />
+ブラウザにインストールしてAmazonにアクセスするだけで、すぐにご利用できます。</p>
+<p><a href="/top/install">» インストール方法はこちらをご覧ください。</a></p>
+
+<div class="animation">
+  <img width="500" src="./images/usage/howtouse.gif" />
+</div>
+
+<div class="flow">
+<h2 class="num1">拡張機能バーのLibronのアイコンをクリックします。</h2>
+<p><img alt="拡張機能バーのLibronのアイコン" src="./images/usage/libron_icon.png" /></p>
+
+<h2 class="num2">図書館設定画面が開くので「変更」リンクをクリックします。</h2>
+<p><img alt="「変更」リンクをクリック" src="./images/usage/popup.png" /></p>
+	
+<h2 class="num3">最寄りの図書館を選択し「保存」ボタンをクリックします</h2>
+<p><img alt="最寄りの図書館を選択" src="./images/usage/popup2.png" /></p>
+
+<h2 class="num4">本を検索します。</h2>
+<p><img alt="本を検索" src="./images/usage/amazon_search_bar.png" /></p>
+
+<h2 class="num5">図書館にその本があれば図書館ページへのリンクが表示されます。</h2>
+<p><img alt="図書館ページへのリンクをクリック" src="./images/usage/amazon_page.png" /></p>`;
+
+  var installContent = `<h1><img alt="インストール方法" width="650" height="72" src="./images/images-subpage/h1_howtoinstall.png" /></h1>
+
+<p>ご利用のブラウザの種類を自動で検出して、対応するインストール方法を表示しています。</p>
+
+<p>別のブラウザをご利用の場合は、以下より選んで下さい。</p>
+
+<ul>
+<li><a href="?browser=Chrome">» Google Chrome 版のインストール方法</a></li>
+<li><a href="?browser=Firefox">» Firefox Greasemonkey 版のインストール方法</a></li>
+</ul>
+
+
+<div class="for-chrome-user" id="chrome">
+<h2><img alt="Google Chrome ユーザーの方へ" width="650" height="80" src="./images/images-subpage/h2_forchromeuser.png" /></h2>
+
+<div class="animation">
+  <img width="500" src="./images/install/install.gif" />
+</div>
+
+<div class="flow">
+<h2 class="num1">Libron をインストールします</h2>
+<p>以下のリンク先より、Libron の Chrome Extension 版をインストールします。<br />
+<a target="_blank" href="https://chrome.google.com/webstore/detail/fpfgglfemmnflnmjminpghmeiajcajoi">&raquo; Libron - Google Chrome extension gallery</a></p>
+<p><img alt="Libron Chrome Extension版のインストール" src="./images/install/chrome_extension.png" /></p>
+
+<h2 class="num2">Libron を拡張機能のバーに固定する</h2>
+<p>Chrome のメニュー右端の方に表示されている拡張機能のアイコン（パズルのピースの形）をクリックし、Libron の右横のピンのアイコンをクリックして拡張機能のバーに固定して常に Libron のアイコンが表示されるようにしておきます。</p>
+<p><img alt="拡張機能バーに固定" src="./images/install/extension_bar.png" /></p>`;
 
   // つかいかたの画像がクリックされたとき
   $("img[alt='つかいかた']").click(function(e) {

--- a/html/index.html
+++ b/html/index.html
@@ -13,6 +13,27 @@
 <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 <script type="text/javascript" src="./javascripts/jquery.featureList-1.0.0.js"></script>
 <script type="text/javascript" src="./javascripts/function.js"></script>
+<script type="text/javascript">
+$(document).ready(function() {
+  // usage.htmlとinstall.htmlの内容を変数として定義
+  var usageContent = "usage";
+  var installContent = "install";
+
+  // つかいかたの画像がクリックされたとき
+  $("img[alt='つかいかた']").click(function(e) {
+    e.preventDefault();
+    // usage.htmlの内容をmain-areaに表示
+    $("#main-area").html(usageContent);
+  });
+
+  // インストール方法の画像がクリックされたとき
+  $("img[alt='インストール方法']").click(function(e) {
+    e.preventDefault();
+    // install.htmlの内容をmain-areaに表示
+    $("#main-area").html(installContent);
+  });
+});
+</script>
 <meta property="og:image" content="./images/logo.png" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css" />
 </head>
@@ -64,11 +85,11 @@
 <div id="navigation">
 <ul class="clearfix">
 <li>
-  <a href="/top/usage">
+  <a href="javascript:void(0);">
 	  <img alt="つかいかた" width="324" height="95" class="rollover" src="./images/images-home/btn_howtouse.png" />
 </a></li>
 <li>
-  <a href="/top/install">
+  <a href="javascript:void(0);">
 	  <img alt="インストール方法" width="324" height="95" class="rollover" src="./images/images-home/btn_howtoinstall.png" />
 </a></li>
 <li class="last">

--- a/html/index.html
+++ b/html/index.html
@@ -15,74 +15,18 @@
 <script type="text/javascript" src="./javascripts/function.js"></script>
 <script type="text/javascript">
 $(document).ready(function() {
-  // usage.htmlとinstall.htmlの内容を変数として定義
-  var usageContent = `<h1><img alt="つかいかた" width="650" height="72" src="./images/images-subpage/h1_howtouse.png" /></h1>
-
-<p>Libron は Amazon のページから最寄りの図書館の蔵書を検索できる便利なツールです。<br />
-ブラウザにインストールしてAmazonにアクセスするだけで、すぐにご利用できます。</p>
-<p><a href="/top/install">» インストール方法はこちらをご覧ください。</a></p>
-
-<div class="animation">
-  <img width="500" src="./images/usage/howtouse.gif" />
-</div>
-
-<div class="flow">
-<h2 class="num1">拡張機能バーのLibronのアイコンをクリックします。</h2>
-<p><img alt="拡張機能バーのLibronのアイコン" src="./images/usage/libron_icon.png" /></p>
-
-<h2 class="num2">図書館設定画面が開くので「変更」リンクをクリックします。</h2>
-<p><img alt="「変更」リンクをクリック" src="./images/usage/popup.png" /></p>
-	
-<h2 class="num3">最寄りの図書館を選択し「保存」ボタンをクリックします</h2>
-<p><img alt="最寄りの図書館を選択" src="./images/usage/popup2.png" /></p>
-
-<h2 class="num4">本を検索します。</h2>
-<p><img alt="本を検索" src="./images/usage/amazon_search_bar.png" /></p>
-
-<h2 class="num5">図書館にその本があれば図書館ページへのリンクが表示されます。</h2>
-<p><img alt="図書館ページへのリンクをクリック" src="./images/usage/amazon_page.png" /></p>`;
-
-  var installContent = `<h1><img alt="インストール方法" width="650" height="72" src="./images/images-subpage/h1_howtoinstall.png" /></h1>
-
-<p>ご利用のブラウザの種類を自動で検出して、対応するインストール方法を表示しています。</p>
-
-<p>別のブラウザをご利用の場合は、以下より選んで下さい。</p>
-
-<ul>
-<li><a href="?browser=Chrome">» Google Chrome 版のインストール方法</a></li>
-<li><a href="?browser=Firefox">» Firefox Greasemonkey 版のインストール方法</a></li>
-</ul>
-
-
-<div class="for-chrome-user" id="chrome">
-<h2><img alt="Google Chrome ユーザーの方へ" width="650" height="80" src="./images/images-subpage/h2_forchromeuser.png" /></h2>
-
-<div class="animation">
-  <img width="500" src="./images/install/install.gif" />
-</div>
-
-<div class="flow">
-<h2 class="num1">Libron をインストールします</h2>
-<p>以下のリンク先より、Libron の Chrome Extension 版をインストールします。<br />
-<a target="_blank" href="https://chrome.google.com/webstore/detail/fpfgglfemmnflnmjminpghmeiajcajoi">&raquo; Libron - Google Chrome extension gallery</a></p>
-<p><img alt="Libron Chrome Extension版のインストール" src="./images/install/chrome_extension.png" /></p>
-
-<h2 class="num2">Libron を拡張機能のバーに固定する</h2>
-<p>Chrome のメニュー右端の方に表示されている拡張機能のアイコン（パズルのピースの形）をクリックし、Libron の右横のピンのアイコンをクリックして拡張機能のバーに固定して常に Libron のアイコンが表示されるようにしておきます。</p>
-<p><img alt="拡張機能バーに固定" src="./images/install/extension_bar.png" /></p>`;
-
   // つかいかたの画像がクリックされたとき
   $("img[alt='つかいかた']").click(function(e) {
     e.preventDefault();
-    // usage.htmlの内容をmain-areaに表示
-    $("#main-area").html(usageContent);
+    // main-areaにiframeを作成してusage.htmlを表示
+    $("#main-area").html('<iframe src="usage.html" width="100%" height="800" frameborder="0"></iframe>');
   });
 
   // インストール方法の画像がクリックされたとき
   $("img[alt='インストール方法']").click(function(e) {
     e.preventDefault();
-    // install.htmlの内容をmain-areaに表示
-    $("#main-area").html(installContent);
+    // main-areaにiframeを作成してinstall.htmlを表示
+    $("#main-area").html('<iframe src="install.html" width="100%" height="800" frameborder="0"></iframe>');
   });
 });
 </script>


### PR DESCRIPTION
「つかいかた」の画像をクリックしたらmain-areaの中身をusage.htmlに、「インストール方法」の画像をクリックしたらinstall.htmlに切り替える機能を実装しました。