### PR TITLE
iframeの代わりにfetch APIを使ってページ内容を読み込むように変更

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -18,15 +18,31 @@ $(document).ready(function() {
   // つかいかたの画像がクリックされたとき
   $("img[alt='つかいかた']").click(function(e) {
     e.preventDefault();
-    // main-areaにiframeを作成してusage.htmlを表示
-    $("#main-area").html('<iframe src="usage.html" width="100%" height="800" frameborder="0"></iframe>');
+    // fetch APIを使ってusage.htmlの内容を取得
+    fetch('usage.html')
+      .then(response => response.text())
+      .then(html => {
+        // 取得したHTMLをmain-areaに直接挿入
+        $("#main-area").html(html);
+      })
+      .catch(error => {
+        console.error('コンテンツの読み込み中にエラーが発生しました:', error);
+      });
   });
 
   // インストール方法の画像がクリックされたとき
   $("img[alt='インストール方法']").click(function(e) {
     e.preventDefault();
-    // main-areaにiframeを作成してinstall.htmlを表示
-    $("#main-area").html('<iframe src="install.html" width="100%" height="800" frameborder="0"></iframe>');
+    // fetch APIを使ってinstall.htmlの内容を取得
+    fetch('install.html')
+      .then(response => response.text())
+      .then(html => {
+        // 取得したHTMLをmain-areaに直接挿入
+        $("#main-area").html(html);
+      })
+      .catch(error => {
+        console.error('コンテンツの読み込み中にエラーが発生しました:', error);
+      });
   });
 });
 </script>

--- a/html/install.html
+++ b/html/install.html
@@ -1,0 +1,28 @@
+<h1><img alt="インストール方法" width="650" height="72" src="./images/images-subpage/h1_howtoinstall.png" /></h1>
+
+<p>ご利用のブラウザの種類を自動で検出して、対応するインストール方法を表示しています。</p>
+
+<p>別のブラウザをご利用の場合は、以下より選んで下さい。</p>
+
+<ul>
+<li><a href="?browser=Chrome">» Google Chrome 版のインストール方法</a></li>
+<li><a href="?browser=Firefox">» Firefox Greasemonkey 版のインストール方法</a></li>
+</ul>
+
+
+<div class="for-chrome-user" id="chrome">
+<h2><img alt="Google Chrome ユーザーの方へ" width="650" height="80" src="./images/images-subpage/h2_forchromeuser.png" /></h2>
+
+<div class="animation">
+  <img width="500" src="./images/install/install.gif" />
+</div>
+
+<div class="flow">
+<h2 class="num1">Libron をインストールします</h2>
+<p>以下のリンク先より、Libron の Chrome Extension 版をインストールします。<br />
+<a target="_blank" href="https://chrome.google.com/webstore/detail/fpfgglfemmnflnmjminpghmeiajcajoi">&raquo; Libron - Google Chrome extension gallery</a></p>
+<p><img alt="Libron Chrome Extension版のインストール" src="./images/install/chrome_extension.png" /></p>
+
+<h2 class="num2">Libron を拡張機能のバーに固定する</h2>
+<p>Chrome のメニュー右端の方に表示されている拡張機能のアイコン（パズルのピースの形）をクリックし、Libron の右横のピンのアイコンをクリックして拡張機能のバーに固定して常に Libron のアイコンが表示されるようにしておきます。</p>
+<p><img alt="拡張機能バーに固定" src="./images/install/extension_bar.png" /></p>

--- a/html/usage.html
+++ b/html/usage.html
@@ -1,0 +1,25 @@
+<h1><img alt="つかいかた" width="650" height="72" src="./images/images-subpage/h1_howtouse.png" /></h1>
+
+<p>Libron は Amazon のページから最寄りの図書館の蔵書を検索できる便利なツールです。<br />
+ブラウザにインストールしてAmazonにアクセスするだけで、すぐにご利用できます。</p>
+<p><a href="/top/install">» インストール方法はこちらをご覧ください。</a></p>
+
+<div class="animation">
+  <img width="500" src="./images/usage/howtouse.gif" />
+</div>
+
+<div class="flow">
+<h2 class="num1">拡張機能バーのLibronのアイコンをクリックします。</h2>
+<p><img alt="拡張機能バーのLibronのアイコン" src="./images/usage/libron_icon.png" /></p>
+
+<h2 class="num2">図書館設定画面が開くので「変更」リンクをクリックします。</h2>
+<p><img alt="「変更」リンクをクリック" src="./images/usage/popup.png" /></p>
+	
+<h2 class="num3">最寄りの図書館を選択し「保存」ボタンをクリックします</h2>
+<p><img alt="最寄りの図書館を選択" src="./images/usage/popup2.png" /></p>
+
+<h2 class="num4">本を検索します。</h2>
+<p><img alt="本を検索" src="./images/usage/amazon_search_bar.png" /></p>
+
+<h2 class="num5">図書館にその本があれば図書館ページへのリンクが表示されます。</h2>
+<p><img alt="図書館ページへのリンクをクリック" src="./images/usage/amazon_page.png" /></p>


### PR DESCRIPTION
iframeを使ってページの内容を切り替えている部分を変更し、fetch APIを使ってinstall.htmlおよびusage.htmlの内容を読み込むようにしました。これにより、ページ遷移がよりスムーズになります。