### PR TITLE
ページ切り替え方法の改善

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -14,37 +14,7 @@
 <script type="text/javascript" src="./javascripts/jquery.featureList-1.0.0.js"></script>
 <script type="text/javascript" src="./javascripts/function.js"></script>
 <script type="text/javascript">
-$(document).ready(function() {
-  // つかいかたの画像がクリックされたとき
-  $("img[alt='つかいかた']").click(function(e) {
-    e.preventDefault();
-    // fetch APIを使ってusage.htmlの内容を取得
-    fetch('usage.html')
-      .then(response => response.text())
-      .then(html => {
-        // 取得したHTMLをmain-areaに直接挿入
-        $("#main-area").html(html);
-      })
-      .catch(error => {
-        console.error('コンテンツの読み込み中にエラーが発生しました:', error);
-      });
-  });
-
-  // インストール方法の画像がクリックされたとき
-  $("img[alt='インストール方法']").click(function(e) {
-    e.preventDefault();
-    // fetch APIを使ってinstall.htmlの内容を取得
-    fetch('install.html')
-      .then(response => response.text())
-      .then(html => {
-        // 取得したHTMLをmain-areaに直接挿入
-        $("#main-area").html(html);
-      })
-      .catch(error => {
-        console.error('コンテンツの読み込み中にエラーが発生しました:', error);
-      });
-  });
-});
+// ページ切り替え機能は function.js の loadPage 関数に移動しました
 </script>
 <meta property="og:image" content="./images/logo.png" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css" />
@@ -97,11 +67,11 @@ $(document).ready(function() {
 <div id="navigation">
 <ul class="clearfix">
 <li>
-  <a href="javascript:void(0);">
+  <a href="javascript:loadPage('usage.html');">
 	  <img alt="つかいかた" width="324" height="95" class="rollover" src="./images/images-home/btn_howtouse.png" />
 </a></li>
 <li>
-  <a href="javascript:void(0);">
+  <a href="javascript:loadPage('install.html');">
 	  <img alt="インストール方法" width="324" height="95" class="rollover" src="./images/images-home/btn_howtoinstall.png" />
 </a></li>
 <li class="last">

--- a/html/index.html
+++ b/html/index.html
@@ -13,9 +13,7 @@
 <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 <script type="text/javascript" src="./javascripts/jquery.featureList-1.0.0.js"></script>
 <script type="text/javascript" src="./javascripts/function.js"></script>
-<script type="text/javascript">
-// ページ切り替え機能は function.js の loadPage 関数に移動しました
-</script>
+
 <meta property="og:image" content="./images/logo.png" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css" />
 </head>

--- a/html/javascripts/function.js
+++ b/html/javascripts/function.js
@@ -45,7 +45,11 @@ function slideVisual(){
 	);
 }
 
-
+// ページコンテンツを読み込む関数
+function loadPage(pageName) {
+	// ページ全体をリロードする
+	window.location.href = pageName;
+}
 
 //////////////////////////////////////////////////////
 

--- a/html/javascripts/function.js
+++ b/html/javascripts/function.js
@@ -47,8 +47,16 @@ function slideVisual(){
 
 // ページコンテンツを読み込む関数
 function loadPage(pageName) {
-	// ページ全体をリロードする
-	window.location.href = pageName;
+	// fetch APIを使ってページの内容を取得
+	fetch(pageName)
+		.then(response => response.text())
+		.then(html => {
+			// 取得したHTMLをmain-areaに直接挿入
+			$("#main-area").html(html);
+		})
+		.catch(error => {
+			console.error('コンテンツの読み込み中にエラーが発生しました:', error);
+		});
 }
 
 //////////////////////////////////////////////////////

--- a/html/usage.html
+++ b/html/usage.html
@@ -2,7 +2,7 @@
 
 <p>Libron は Amazon のページから最寄りの図書館の蔵書を検索できる便利なツールです。<br />
 ブラウザにインストールしてAmazonにアクセスするだけで、すぐにご利用できます。</p>
-<p><a href="/top/install">» インストール方法はこちらをご覧ください。</a></p>
+<p><a href="javascript:loadPage('install.html');">» インストール方法はこちらをご覧ください。</a></p>
 
 <div class="animation">
   <img width="500" src="./images/usage/howtouse.gif" />


### PR DESCRIPTION
ページの内容を切り替えるとき、click イベントをトリガーにするのでなく、a タグの中から関数を呼び出す方式に変更しました。\n\n- click イベントのコードを削除し、loadPage 関数を追加\n- a タグから直接 loadPage 関数を呼び出すように変更