### PR TITLE
お問い合わせ・プライバシーポリシーページで特定要素を非表示にする

### DIFF
--- a/html/javascripts/function.js
+++ b/html/javascripts/function.js
@@ -53,6 +53,14 @@ function loadPage(pageName) {
 		.then(html => {
 			// 取得したHTMLをmain-areaに直接挿入
 			$("#main-area").html(html);
+			
+			// お問い合わせページまたはプライバシーポリシーページの場合、特定の要素を非表示にする
+			if (pageName === 'contact.html' || pageName === 'pp.html') {
+				$("#sub-area, #visual, #navigation").hide();
+			} else {
+				// それ以外のページでは表示する
+				$("#sub-area, #visual, #navigation").show();
+			}
 		})
 		.catch(error => {
 			console.error('コンテンツの読み込み中にエラーが発生しました:', error);


### PR DESCRIPTION
お問い合わせページとプライバシーポリシーページに切り替えたときに、div#sub-area、div#visual、div#navigationを非表示にする機能を追加しました。